### PR TITLE
feat(auth & leaderboard): add apple login base api & get leaderboard entries api

### DIFF
--- a/src/core/auth/i-services/i-apple-login.service.ts
+++ b/src/core/auth/i-services/i-apple-login.service.ts
@@ -1,0 +1,14 @@
+import { UserDomain } from '../../user';
+
+export class AppleLoginServiceInput {
+  constructor(
+    public readonly appleId: string,
+    public readonly email: string,
+  ) {}
+}
+
+export interface IAppleLoginService {
+  execute(
+    dto: AppleLoginServiceInput,
+  ): Promise<UserDomain & { isNewUser: boolean }>;
+}

--- a/src/core/auth/i-services/index.ts
+++ b/src/core/auth/i-services/index.ts
@@ -1,2 +1,3 @@
+export * from './i-apple-login.service';
 export * from './i-cancel-account-by-user-id.service';
 export * from './i-google-login.service';

--- a/src/core/leaderboard/i-services/i-get-leaderboard-entries.service.ts
+++ b/src/core/leaderboard/i-services/i-get-leaderboard-entries.service.ts
@@ -1,0 +1,34 @@
+export class GetLeaderBoardEntriesServiceInput {
+  constructor(
+    public readonly key: string,
+    public readonly groupId: number = 0,
+    public readonly type: 'daily' | 'weekly' | 'monthly' = 'daily',
+    public readonly offset: number = 0,
+    public readonly limit: number = 10,
+  ) {}
+}
+
+export class GetLeaderboardEntriesServiceOutput {
+  constructor(
+    public readonly entries: LeaderboardEntry[],
+    public readonly totalCount: number,
+    public readonly hasNextPage: boolean,
+    public readonly hasPreviousPage: boolean,
+  ) {}
+}
+
+export class LeaderboardEntry {
+  constructor(
+    public readonly rank: number,
+    public readonly score: number,
+    public readonly userId: number,
+    public readonly nickname: string | null,
+    public readonly thumbnailUrl: string | null,
+  ) {}
+}
+
+export interface IGetLeaderboardEntriesService {
+  execute(
+    dto: GetLeaderBoardEntriesServiceInput,
+  ): Promise<GetLeaderboardEntriesServiceOutput>;
+}

--- a/src/core/leaderboard/i-services/index.ts
+++ b/src/core/leaderboard/i-services/index.ts
@@ -1,0 +1,1 @@
+export * from './i-get-leaderboard-entries.service';

--- a/src/core/leaderboard/index.ts
+++ b/src/core/leaderboard/index.ts
@@ -1,0 +1,1 @@
+export * from './i-services';

--- a/src/core/study-record/i-repositories/i-count-study-records-by-type.repository.ts
+++ b/src/core/study-record/i-repositories/i-count-study-records-by-type.repository.ts
@@ -1,0 +1,5 @@
+import { GetLeaderBoardEntriesServiceInput } from '../../leaderboard';
+
+export interface ICountStudyRecordsByTypeRepository {
+  execute(predicate: GetLeaderBoardEntriesServiceInput): Promise<number>;
+}

--- a/src/core/study-record/i-repositories/i-get-study-records-by-rank.repository.ts
+++ b/src/core/study-record/i-repositories/i-get-study-records-by-rank.repository.ts
@@ -1,0 +1,8 @@
+import { GetLeaderBoardEntriesServiceInput } from '../../leaderboard';
+import { IBaseGetEntitiesRepository } from '../../lib/i-base-repositories';
+import { StudyRecordDomain } from '../study-record.domain';
+
+export type IGetStudyRecordsByRankRepository = IBaseGetEntitiesRepository<
+  GetLeaderBoardEntriesServiceInput,
+  StudyRecordDomain
+>;

--- a/src/core/study-record/i-repositories/index.ts
+++ b/src/core/study-record/i-repositories/index.ts
@@ -1,4 +1,6 @@
+export * from './i-count-study-records-by-type.repository';
 export * from './i-create-study-record.repository';
 export * from './i-get-study-record-by-date.repository';
 export * from './i-get-study-records-by-range.repository';
+export * from './i-get-study-records-by-rank.repository';
 export * from './i-update-study-record.repository';

--- a/src/core/study-record/study-record.domain.ts
+++ b/src/core/study-record/study-record.domain.ts
@@ -1,7 +1,7 @@
 export interface StudyRecordDomain {
   studyRecordId: string;
   date: string;
-  userId: number;
+  userId: bigint;
   goalDuration: number | null;
   totalDuration: number;
   studies: Study[];

--- a/src/core/user/i-repositories/i-get-users-by-user-ids.repository.ts
+++ b/src/core/user/i-repositories/i-get-users-by-user-ids.repository.ts
@@ -1,0 +1,7 @@
+import { IBaseGetEntitiesRepository } from '../../lib/i-base-repositories';
+import { UserDomain } from '../user.domain';
+
+export type IGetUsersByUserIdsRepository = IBaseGetEntitiesRepository<
+  number[],
+  UserDomain
+>;

--- a/src/core/user/i-repositories/index.ts
+++ b/src/core/user/i-repositories/index.ts
@@ -1,3 +1,4 @@
 export * from './i-create-user.repository';
 export * from './i-get-user-by-user-id.repository';
+export * from './i-get-users-by-user-ids.repository';
 export * from './i-save-user.repository';

--- a/src/core/user/i-services/i-get-user-info.service.ts
+++ b/src/core/user/i-services/i-get-user-info.service.ts
@@ -1,0 +1,5 @@
+import { UserDomain } from '../user.domain';
+
+export interface IGetUserInfoService {
+  execute(userId: number): Promise<UserDomain>;
+}

--- a/src/core/user/i-services/index.ts
+++ b/src/core/user/i-services/index.ts
@@ -1,1 +1,2 @@
+export * from './i-get-user-info.service';
 export * from './i-update-user.service';

--- a/src/framework/app.module.ts
+++ b/src/framework/app.module.ts
@@ -6,6 +6,7 @@ import { AuthModule } from './auth/auth.module';
 import { AccessTokenGuard } from './auth/guards';
 import { JwtTokenProvider } from './auth/providers';
 import { DdayModule } from './dday/dday.module';
+import { LeaderboardModule } from './leaderboard/leaderboard.module';
 import { StudyRecordModule } from './study-record/study-record.module';
 import { SubjectModule } from './subject/subject.module';
 import { UserModule } from './user/user.module';
@@ -18,12 +19,14 @@ import { UserModule } from './user/user.module';
     DdayModule,
     SubjectModule,
     StudyRecordModule,
+    LeaderboardModule,
     RouterModule.register([
       { path: 'auth', children: [AuthModule] },
       { path: 'dday', children: [DdayModule] },
       { path: 'users', children: [UserModule] },
       { path: 'subjects', children: [SubjectModule] },
       { path: 'study-records', children: [StudyRecordModule] },
+      { path: 'leaderboards', children: [LeaderboardModule] },
     ]),
   ],
   providers: [

--- a/src/framework/auth/auth.module.ts
+++ b/src/framework/auth/auth.module.ts
@@ -7,21 +7,32 @@ import {
   UserEntity,
 } from '../../infra/mysql/entities';
 import {
+  CreateAppleAccountRepository,
   CreateGoogleAccountRepository,
   CreateRefreshTokenRepository,
   CreateUserRepository,
   GetAccountByUserIdRepository,
+  GetAppleAccountRepository,
   GetGoogleAccountRepository,
   GetRefreshTokenRepository,
   SoftDeleteAccountByAccountIdRepository,
 } from '../../infra/mysql/repositories';
 import { DbContextProvider, UnitOfWorkProvider } from '../shared/providers';
-import { GoogleLoginController, RefreshTokenController } from './controllers';
+import {
+  AppleLoginController,
+  GoogleLoginController,
+  RefreshTokenController,
+} from './controllers';
 import { CancelAccountController } from './controllers/cancel-account';
 import { JwtTokenProvider, RefreshTokenProvider } from './providers';
-import { CancelAccountByUserIdService, GoogleLoginService } from './services';
+import {
+  AppleLoginService,
+  CancelAccountByUserIdService,
+  GoogleLoginService,
+} from './services';
 
 const controllers = [
+  AppleLoginController,
   GoogleLoginController,
   RefreshTokenController,
   CancelAccountController,
@@ -44,13 +55,15 @@ const repositories = [
   GetRefreshTokenRepository,
   GetAccountByUserIdRepository,
   SoftDeleteAccountByAccountIdRepository,
+  GetAppleAccountRepository,
+  CreateAppleAccountRepository,
 ];
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([AccountEntity, UserEntity, RefreshTokenEntity]),
   ],
-  controllers,
-  providers: [...services, ...repositories, ...providers],
+  controllers: [...controllers],
+  providers: [...services, ...repositories, ...providers, AppleLoginService],
 })
 export class AuthModule {}

--- a/src/framework/auth/controllers/apple-login/apple-login.controller.ts
+++ b/src/framework/auth/controllers/apple-login/apple-login.controller.ts
@@ -1,0 +1,56 @@
+import { TypedBody, TypedRoute } from '@nestia/core';
+import { Controller, Inject } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+
+import {
+  IAppleLoginService,
+  IJwtTokenProvider,
+  IRefreshTokenProvider,
+} from '../../../../core/auth';
+import { tokenEnv } from '../../../app-config/envs';
+import { Public } from '../../../shared/decorators';
+import { JwtTokenProvider, RefreshTokenProvider } from '../../providers';
+import { AppleLoginService } from '../../services';
+import { IGoogleLoginResDto } from '../google-login';
+import { IAppleLoginReqDto } from './i-apple-login.req.dto';
+
+@Controller()
+export class AppleLoginController {
+  constructor(
+    @Inject(tokenEnv.KEY)
+    private readonly tokenConfig: ConfigType<typeof tokenEnv>,
+    @Inject(AppleLoginService)
+    private readonly appleLoginService: IAppleLoginService,
+    @Inject(JwtTokenProvider)
+    private readonly jwtTokenProvider: IJwtTokenProvider,
+    @Inject(RefreshTokenProvider)
+    private readonly refreshTokenProvider: IRefreshTokenProvider,
+  ) {}
+
+  @Public()
+  @TypedRoute.Post('apple')
+  public async execute(
+    @TypedBody() body: IAppleLoginReqDto,
+  ): Promise<IGoogleLoginResDto> {
+    const loginResult = await this.appleLoginService.execute(body);
+
+    const expiresAt =
+      Math.floor(Date.now() / 1000) + this.tokenConfig.jwtExpiresInSeconds;
+
+    const accessToken = await this.jwtTokenProvider.sign({
+      userId: loginResult.userId,
+    });
+
+    const refreshToken = await this.refreshTokenProvider.generate(
+      loginResult.userId,
+    );
+
+    return {
+      accessToken,
+      refreshToken,
+      expiresAt,
+      isNewUser: loginResult.isNewUser,
+      userId: loginResult.userId,
+    };
+  }
+}

--- a/src/framework/auth/controllers/apple-login/i-apple-login.req.dto.ts
+++ b/src/framework/auth/controllers/apple-login/i-apple-login.req.dto.ts
@@ -1,0 +1,6 @@
+import { tags } from 'typia';
+
+export interface IAppleLoginReqDto {
+  appleId: string & tags.MaxLength<255>;
+  email: string & tags.Format<'email'>;
+}

--- a/src/framework/auth/controllers/apple-login/index.ts
+++ b/src/framework/auth/controllers/apple-login/index.ts
@@ -1,0 +1,1 @@
+export * from './apple-login.controller';

--- a/src/framework/auth/controllers/google-login/index.ts
+++ b/src/framework/auth/controllers/google-login/index.ts
@@ -1,1 +1,2 @@
 export * from './google-login.controller';
+export * from './i-google-login.res.dto';

--- a/src/framework/auth/controllers/index.ts
+++ b/src/framework/auth/controllers/index.ts
@@ -1,2 +1,3 @@
+export * from './apple-login';
 export * from './google-login';
 export * from './refresh-token';

--- a/src/framework/auth/services/index.ts
+++ b/src/framework/auth/services/index.ts
@@ -1,2 +1,3 @@
+export * from './apple-login.service';
 export * from './cancel-account-by-user-id.service';
 export * from './google-login.service';

--- a/src/framework/leaderboard/controllers/get-leaderboard-entries.controller.ts
+++ b/src/framework/leaderboard/controllers/get-leaderboard-entries.controller.ts
@@ -1,0 +1,33 @@
+import { TypedQuery, TypedRoute } from '@nestia/core';
+import { Controller, Inject } from '@nestjs/common';
+
+import {
+  GetLeaderBoardEntriesServiceInput,
+  IGetLeaderboardEntriesService,
+} from '../../../core/leaderboard';
+import { GetLeaderboardEntriesService } from '../services';
+import { IGetLeaderboardEntriesReqDto } from './i-get-leaderboard-entries.req.dto';
+import { IGetLeaderboardEntriesResDto } from './i-get-leaderboard-entries.res.dto';
+
+@Controller()
+export class GetLeaderboardEntriesController {
+  constructor(
+    @Inject(GetLeaderboardEntriesService)
+    private readonly getLeaderboardEntriesService: IGetLeaderboardEntriesService,
+  ) {}
+
+  @TypedRoute.Get('entries')
+  public async execute(
+    @TypedQuery() query: IGetLeaderboardEntriesReqDto,
+  ): Promise<IGetLeaderboardEntriesResDto> {
+    return await this.getLeaderboardEntriesService.execute(
+      new GetLeaderBoardEntriesServiceInput(
+        query.key,
+        query.groupId,
+        query.type,
+        query.offset,
+        query.limit,
+      ),
+    );
+  }
+}

--- a/src/framework/leaderboard/controllers/i-get-leaderboard-entries.req.dto.ts
+++ b/src/framework/leaderboard/controllers/i-get-leaderboard-entries.req.dto.ts
@@ -1,0 +1,7 @@
+export interface IGetLeaderboardEntriesReqDto {
+  key: string;
+  type?: 'daily' | 'weekly' | 'monthly';
+  groupId?: number;
+  offset?: number;
+  limit?: number;
+}

--- a/src/framework/leaderboard/controllers/i-get-leaderboard-entries.res.dto.ts
+++ b/src/framework/leaderboard/controllers/i-get-leaderboard-entries.res.dto.ts
@@ -1,0 +1,8 @@
+import { LeaderboardEntry } from '../../../core/leaderboard';
+
+export interface IGetLeaderboardEntriesResDto {
+  entries: LeaderboardEntry[];
+  totalCount: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+}

--- a/src/framework/leaderboard/controllers/index.ts
+++ b/src/framework/leaderboard/controllers/index.ts
@@ -1,0 +1,1 @@
+export * from './get-leaderboard-entries.controller';

--- a/src/framework/leaderboard/leaderboard.module.ts
+++ b/src/framework/leaderboard/leaderboard.module.ts
@@ -1,0 +1,35 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import {
+  CountStudyRecordsByTypeRepository,
+  GetStudyRecordsByRankRepository,
+} from '../../infra/mongo/repositories';
+import { StudyRecordModel, StudyRecordSchema } from '../../infra/mongo/schemas';
+import { UserEntity } from '../../infra/mysql/entities';
+import { GetUsersByUserIdsRepository } from '../../infra/mysql/repositories';
+import { GetLeaderboardEntriesController } from './controllers';
+import { GetLeaderboardEntriesService } from './services';
+
+const controllers = [GetLeaderboardEntriesController];
+
+const services = [GetLeaderboardEntriesService];
+
+const repositories = [
+  GetStudyRecordsByRankRepository,
+  CountStudyRecordsByTypeRepository,
+  GetUsersByUserIdsRepository,
+];
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([UserEntity]),
+    MongooseModule.forFeature([
+      { name: StudyRecordModel.name, schema: StudyRecordSchema },
+    ]),
+  ],
+  controllers: [...controllers],
+  providers: [...services, ...repositories],
+})
+export class LeaderboardModule {}

--- a/src/framework/leaderboard/services/get-leaderboard-entries.service.ts
+++ b/src/framework/leaderboard/services/get-leaderboard-entries.service.ts
@@ -1,0 +1,72 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import {
+  GetLeaderBoardEntriesServiceInput,
+  GetLeaderboardEntriesServiceOutput,
+  IGetLeaderboardEntriesService,
+} from '../../../core/leaderboard';
+import {
+  ICountStudyRecordsByTypeRepository,
+  IGetStudyRecordsByRankRepository,
+} from '../../../core/study-record';
+import { IGetUsersByUserIdsRepository } from '../../../core/user';
+import {
+  CountStudyRecordsByTypeRepository,
+  GetStudyRecordsByRankRepository,
+} from '../../../infra/mongo/repositories';
+import { GetUsersByUserIdsRepository } from '../../../infra/mysql/repositories';
+
+@Injectable()
+export class GetLeaderboardEntriesService
+  implements IGetLeaderboardEntriesService
+{
+  constructor(
+    @Inject(CountStudyRecordsByTypeRepository)
+    private readonly countStudyRecordsByTypeRepository: ICountStudyRecordsByTypeRepository,
+    @Inject(GetStudyRecordsByRankRepository)
+    private readonly getStudyRecordsByRankRepository: IGetStudyRecordsByRankRepository,
+    @Inject(GetUsersByUserIdsRepository)
+    private readonly getUsersByUserIdsRepository: IGetUsersByUserIdsRepository,
+  ) {}
+
+  public async execute(
+    dto: GetLeaderBoardEntriesServiceInput,
+  ): Promise<GetLeaderboardEntriesServiceOutput> {
+    const entries = await this.getStudyRecordsByRankRepository.execute(dto);
+    const totalCount =
+      await this.countStudyRecordsByTypeRepository.execute(dto);
+
+    const userIds = entries.map((entry) => Number(entry.userId));
+
+    const users = await this.getUsersByUserIdsRepository.execute(userIds);
+
+    const userMap = new Map<
+      number,
+      { nickname: string | null; thumbnailUrl: string | null }
+    >();
+    for (const user of users) {
+      userMap.set(user.userId, {
+        nickname: user.nickname,
+        thumbnailUrl: null,
+      });
+    }
+
+    const mappedEntries = entries.map((entry, index) => {
+      const user = userMap.get(Number(entry.userId));
+      return {
+        rank: dto.offset + index + 1,
+        score: entry.totalDuration,
+        userId: userIds[index],
+        nickname: user?.nickname ?? null,
+        thumbnailUrl: user?.thumbnailUrl ?? null,
+      };
+    });
+
+    return {
+      totalCount,
+      hasNextPage: totalCount > dto.offset + dto.limit,
+      hasPreviousPage: dto.offset > 0,
+      entries: mappedEntries,
+    };
+  }
+}

--- a/src/framework/leaderboard/services/index.ts
+++ b/src/framework/leaderboard/services/index.ts
@@ -1,0 +1,1 @@
+export * from './get-leaderboard-entries.service';

--- a/src/framework/user/controllers/get-user-info/get-user-info.controller.ts
+++ b/src/framework/user/controllers/get-user-info/get-user-info.controller.ts
@@ -1,0 +1,27 @@
+import { TypedRoute } from '@nestia/core';
+import { Controller, Inject } from '@nestjs/common';
+
+import { JwtPayload } from '../../../../core/auth';
+import { IGetUserInfoService } from '../../../../core/user';
+import { CurrentUser } from '../../../shared/decorators';
+import { GetUserInfoService } from '../../services';
+import { IGetUserInfoResDto } from './i-get-user-info.res.dto';
+
+@Controller()
+export class GetUserInfoController {
+  constructor(
+    @Inject(GetUserInfoService)
+    private readonly getUserInfoService: IGetUserInfoService,
+  ) {}
+
+  @TypedRoute.Get()
+  public async execute(
+    @CurrentUser() user: JwtPayload,
+  ): Promise<IGetUserInfoResDto> {
+    const userDomain = await this.getUserInfoService.execute(user.userId);
+
+    return {
+      nickname: userDomain.nickname,
+    };
+  }
+}

--- a/src/framework/user/controllers/get-user-info/i-get-user-info.res.dto.ts
+++ b/src/framework/user/controllers/get-user-info/i-get-user-info.res.dto.ts
@@ -1,0 +1,3 @@
+export interface IGetUserInfoResDto {
+  nickname: string | null;
+}

--- a/src/framework/user/controllers/get-user-info/index.ts
+++ b/src/framework/user/controllers/get-user-info/index.ts
@@ -1,0 +1,1 @@
+export * from './get-user-info.controller';

--- a/src/framework/user/controllers/index.ts
+++ b/src/framework/user/controllers/index.ts
@@ -1,0 +1,2 @@
+export * from './get-user-info';
+export * from './update-profile';

--- a/src/framework/user/services/get-user-info.service.ts
+++ b/src/framework/user/services/get-user-info.service.ts
@@ -1,0 +1,31 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import {
+  IGetUserByUserIdRepository,
+  IGetUserInfoService,
+  UserDomain,
+  UserExceptionEnum,
+} from '../../../core/user';
+import { GetUserByUserIdRepository } from '../../../infra/mysql/repositories';
+import { throwNotFoundException } from '../../shared/exceptions';
+
+@Injectable()
+export class GetUserInfoService implements IGetUserInfoService {
+  constructor(
+    @Inject(GetUserByUserIdRepository)
+    private readonly getUserByUserIdRepository: IGetUserByUserIdRepository,
+  ) {}
+
+  public async execute(userId: number): Promise<UserDomain> {
+    const user = await this.getUserByUserIdRepository.execute(userId);
+
+    if (!user) {
+      return throwNotFoundException(
+        "The requested user doesn't exist.",
+        UserExceptionEnum.USER_NOT_FOUND,
+      );
+    }
+
+    return user;
+  }
+}

--- a/src/framework/user/services/index.ts
+++ b/src/framework/user/services/index.ts
@@ -1,1 +1,2 @@
+export * from './get-user-info.service';
 export * from './update-user.service';

--- a/src/framework/user/user.module.ts
+++ b/src/framework/user/user.module.ts
@@ -6,18 +6,18 @@ import {
   GetUserByUserIdRepository,
   SaveUserRepository,
 } from '../../infra/mysql/repositories';
-import { UpdateUserController } from './controllers/update-profile';
-import { UpdateUserService } from './services';
+import { GetUserInfoController, UpdateUserController } from './controllers';
+import { GetUserInfoService, UpdateUserService } from './services';
 
-const controllers = [UpdateUserController];
+const controllers = [UpdateUserController, GetUserInfoController];
 
-const services = [UpdateUserService];
+const services = [UpdateUserService, GetUserInfoService];
 
 const repositories = [GetUserByUserIdRepository, SaveUserRepository];
 
 @Module({
   imports: [TypeOrmModule.forFeature([UserEntity])],
-  controllers: controllers,
+  controllers: [...controllers],
   providers: [...services, ...repositories],
 })
 export class UserModule {}

--- a/src/infra/mongo/repositories/study-record/count-study-records-by-type.repository.ts
+++ b/src/infra/mongo/repositories/study-record/count-study-records-by-type.repository.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { GetLeaderBoardEntriesServiceInput } from 'src/core/leaderboard';
+
+import { ICountStudyRecordsByTypeRepository } from '../../../../core/study-record';
+import { StudyRecordModel } from '../../schemas';
+
+@Injectable()
+export class CountStudyRecordsByTypeRepository
+  implements ICountStudyRecordsByTypeRepository
+{
+  constructor(
+    @InjectModel(StudyRecordModel.name)
+    private readonly studyRecordModel: Model<StudyRecordModel>,
+  ) {}
+
+  public async execute({
+    key,
+  }: GetLeaderBoardEntriesServiceInput): Promise<number> {
+    return this.studyRecordModel.countDocuments({ date: key }).exec();
+  }
+}

--- a/src/infra/mongo/repositories/study-record/get-study-records-by-rank.repository.ts
+++ b/src/infra/mongo/repositories/study-record/get-study-records-by-rank.repository.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { GetLeaderBoardEntriesServiceInput } from 'src/core/leaderboard';
+import { StudyRecordDomain } from 'src/core/study-record';
+
+import { IGetStudyRecordsByRankRepository } from '../../../../core/study-record';
+import { StudyRecordModel } from '../../schemas';
+
+@Injectable()
+export class GetStudyRecordsByRankRepository
+  implements IGetStudyRecordsByRankRepository
+{
+  constructor(
+    @InjectModel(StudyRecordModel.name)
+    private readonly studyRecordModel: Model<StudyRecordModel>,
+  ) {}
+
+  public async execute({
+    key,
+    offset,
+    limit,
+  }: GetLeaderBoardEntriesServiceInput): Promise<StudyRecordDomain[]> {
+    return this.studyRecordModel
+      .find(
+        { date: key },
+        {
+          userId: 1,
+          totalDuration: 1,
+        },
+      )
+      .skip(offset)
+      .limit(limit)
+      .exec();
+  }
+}

--- a/src/infra/mongo/repositories/study-record/index.ts
+++ b/src/infra/mongo/repositories/study-record/index.ts
@@ -1,4 +1,6 @@
+export * from './count-study-records-by-type.repository';
 export * from './create-study-record.repository';
 export * from './get-study-record-by-date.repository';
 export * from './get-study-records-by-range.repository';
+export * from './get-study-records-by-rank.repository';
 export * from './update-study-record.repository';

--- a/src/infra/mongo/schemas/study-record.schema.ts
+++ b/src/infra/mongo/schemas/study-record.schema.ts
@@ -22,9 +22,9 @@ export class StudyRecordModel extends Document implements StudyRecordDomain {
 
   @Prop({
     required: true,
-    type: Number,
+    type: mongoose.Schema.Types.BigInt,
   })
-  userId: number;
+  userId: bigint;
 
   @Prop({ required: true, type: String })
   date: string;
@@ -60,3 +60,4 @@ export class StudyRecordModel extends Document implements StudyRecordDomain {
 export const StudyRecordSchema = SchemaFactory.createForClass(StudyRecordModel);
 
 StudyRecordSchema.index({ userId: 1, date: 1 }, { unique: true });
+StudyRecordSchema.index({ date: 1 });

--- a/src/infra/mysql/repositories/account/create-apple-account.repository.ts
+++ b/src/infra/mysql/repositories/account/create-apple-account.repository.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+
+import {
+  AccountDomain,
+  AuthProviderEnum,
+  CreateAccountRepositoryInput,
+  ICreateAccountRepository,
+} from '../../../../core/account';
+import { DbContextProvider } from '../../../../framework/shared/providers';
+import { AccountEntity } from '../../entities';
+
+@Injectable()
+export class CreateAppleAccountRepository implements ICreateAccountRepository {
+  constructor(private readonly dbContext: DbContextProvider) {}
+
+  public async execute(
+    params: CreateAccountRepositoryInput,
+  ): Promise<AccountDomain> {
+    const accountRepository = this.dbContext.getRepository(AccountEntity);
+
+    const newAccount = accountRepository.create({
+      authProvider: AuthProviderEnum.apple,
+      authProviderId: params.authProviderId,
+      userId: params.userId,
+      email: params.email,
+    });
+
+    return accountRepository.save(newAccount);
+  }
+}

--- a/src/infra/mysql/repositories/account/get-apple-account.repository.ts
+++ b/src/infra/mysql/repositories/account/get-apple-account.repository.ts
@@ -10,21 +10,18 @@ import {
 import { AccountEntity } from '../../entities';
 
 @Injectable()
-export class GetGoogleAccountRepository implements IGetAccountRepository {
+export class GetAppleAccountRepository implements IGetAccountRepository {
   constructor(
     @InjectRepository(AccountEntity)
     private readonly accountRepository: Repository<AccountEntity>,
   ) {}
-
-  public async execute(googleId: string): Promise<AccountDomain | null> {
+  public async execute(appleId: string): Promise<AccountDomain | null> {
     return this.accountRepository.findOne({
       where: {
-        authProvider: AuthProviderEnum.google,
-        authProviderId: googleId,
+        authProvider: AuthProviderEnum.apple,
+        authProviderId: appleId,
       },
-      relations: {
-        user: true,
-      },
+      relations: { user: true },
       withDeleted: true,
     });
   }

--- a/src/infra/mysql/repositories/account/index.ts
+++ b/src/infra/mysql/repositories/account/index.ts
@@ -1,4 +1,6 @@
+export * from './create-apple-account.repository';
 export * from './create-google-account.repository';
 export * from './get-account-by-user-id.repository';
+export * from './get-apple-account.repository';
 export * from './get-google-account.repository';
 export * from './soft-delete-account-by-account-id.repository';

--- a/src/infra/mysql/repositories/user/get-users-by-user-ids.repository.ts
+++ b/src/infra/mysql/repositories/user/get-users-by-user-ids.repository.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+
+import {
+  IGetUsersByUserIdsRepository,
+  UserDomain,
+} from '../../../../core/user';
+import { UserEntity } from '../../entities';
+
+@Injectable()
+export class GetUsersByUserIdsRepository
+  implements IGetUsersByUserIdsRepository
+{
+  constructor(
+    @InjectRepository(UserEntity)
+    private readonly userRepository: Repository<UserEntity>,
+  ) {}
+
+  public async execute(userIds: number[]): Promise<UserDomain[]> {
+    return this.userRepository.find({
+      select: { userId: true, nickname: true, thumbnailPath: true },
+      where: { userId: In(userIds) },
+    });
+  }
+}

--- a/src/infra/mysql/repositories/user/index.ts
+++ b/src/infra/mysql/repositories/user/index.ts
@@ -1,3 +1,4 @@
 export * from './create-user.repository';
 export * from './get-user-by-user-id.repository';
+export * from './get-users-by-user-ids.repository';
 export * from './save-user.repository';


### PR DESCRIPTION
## 📌 PR 요약
애플 로그인 및 유저 정보 조회, 리더보드 엔트리 조회 api 추가
<!-- 이 PR에서 해결한 내용이나 변경 사항을 간략히 작성해주세요. -->

## 🛠 변경 내용

- 애플 로그인 베이스 api 추가 -> flutter 라이브러리 구현 후 수정 필요
- 리더보드 엔트리 조회 api 추가 -> 추후 redis sorted set으로 변경 필요
- 스플래쉬 스크린에서 앱 데이터 초기화 시 호출할 get user info api 추가

## 🔍 리뷰 요청 사항

<!-- PR에 대한 중점적인 리뷰 요청사항이 있다면 작성해주세요. -->

## 📋 참고 사항

<!-- PR에 대한 추가적인 설명이나 참고 사항이 있다면 작성해주세요. -->